### PR TITLE
Add DNS cache implementation with domain refresh management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +455,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -888,6 +900,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mori"
 version = "0.0.1"
 dependencies = [
@@ -898,6 +936,7 @@ dependencies = [
  "env_logger",
  "hickory-resolver",
  "log",
+ "mockall",
  "rstest",
  "thiserror 2.0.16",
 ]
@@ -1036,6 +1075,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1349,6 +1414,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ aya-log = "0.2.1"
 
 [dev-dependencies]
 rstest = "0.23"
+mockall = "0.13"
 
 [build-dependencies]
 aya-build = "0.1.2"

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,4 @@ run-deny: build
 
 test:
 	@cargo nextest run
+	@cargo test --doc

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ run-allow: build
 
 run-deny: build
 	@sudo ./target/release/mori -- ping -c 1 www.google.com
+
+test:
+	@cargo nextest run

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@
 ### TODO
 - [x] connect4 にフックする eBPF プログラムを作成し cgroup にアタッチする
 - [ ] connect6 にフックする eBPF プログラムを作成し cgroup にアタッチする（IPv6 対応は将来検討）
-- [ ] Hickory DNS による FQDN→IP 解決と eBPF マップ更新ループ（TTL 尊重）を実装する
+- [x] Hickory DNS による FQDN→IP 解決と eBPF マップ更新ループ（TTL 尊重）を実装する
 - [ ] mori CLI / 設定ポリシーから Linux ネットワーク許可ルール（FQDN / IP / CIDR）への変換レイヤーを実装する
 - [ ] 拒否イベントのログ出力と最低限の観測手段（構造化ログ等）を整備する
 - [ ] Landlock へのマッピングコード（Rust）を CLI 層と分離したモジュールとして設計する

--- a/src/net/cache.rs
+++ b/src/net/cache.rs
@@ -1,0 +1,135 @@
+use std::{
+    collections::HashMap,
+    net::Ipv4Addr,
+    time::{Duration, Instant},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Entry {
+    pub ip: Ipv4Addr,
+    pub expires_at: Instant,
+}
+
+#[derive(Default, Debug)]
+pub struct UpdateDiff {
+    pub added: Vec<Ipv4Addr>,
+    pub removed: Vec<Ipv4Addr>,
+}
+
+#[derive(Default, Debug)]
+pub struct DnsCache {
+    per_domain: HashMap<String, HashMap<Ipv4Addr, Instant>>,
+}
+
+impl DnsCache {
+    pub fn apply(&mut self, domain: &str, now: Instant, entries: Vec<Entry>) -> UpdateDiff {
+        let state = self.per_domain.entry(domain.to_string()).or_default();
+
+        let mut new_state: HashMap<Ipv4Addr, Instant> = HashMap::new();
+        for entry in entries {
+            if entry.expires_at <= now {
+                continue;
+            }
+            new_state
+                .entry(entry.ip)
+                .and_modify(|expires| {
+                    if *expires < entry.expires_at {
+                        *expires = entry.expires_at;
+                    }
+                })
+                .or_insert(entry.expires_at);
+        }
+
+        let mut removed: Vec<Ipv4Addr> = state
+            .keys()
+            .filter(|ip| !new_state.contains_key(ip))
+            .copied()
+            .collect();
+
+        let mut added: Vec<Ipv4Addr> = new_state
+            .keys()
+            .filter(|ip| !state.contains_key(ip))
+            .copied()
+            .collect();
+
+        *state = new_state;
+
+        removed.sort();
+        removed.dedup();
+        added.sort();
+        added.dedup();
+
+        UpdateDiff { added, removed }
+    }
+
+    pub fn next_refresh_in(&self, now: Instant) -> Option<Duration> {
+        self.per_domain
+            .values()
+            .flat_map(|ips| ips.values())
+            .map(|expires| expires.saturating_duration_since(now))
+            .min()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn adds_new_ips() {
+        let mut cache = DnsCache::default();
+        let now = Instant::now();
+        let entry = Entry {
+            ip: Ipv4Addr::new(192, 168, 0, 1),
+            expires_at: now + Duration::from_secs(60),
+        };
+
+        let diff = cache.apply("example.com", now, vec![entry.clone()]);
+
+        assert_eq!(diff.added, vec![entry.ip]);
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn expires_old_ips() {
+        let mut cache = DnsCache::default();
+        let now = Instant::now();
+        let entry = Entry {
+            ip: Ipv4Addr::new(10, 0, 0, 1),
+            expires_at: now + Duration::from_secs(30),
+        };
+        cache.apply("example.com", now, vec![entry.clone()]);
+
+        let later = now + Duration::from_secs(45);
+        let diff = cache.apply("example.com", later, vec![]);
+
+        assert!(diff.added.is_empty());
+        assert_eq!(diff.removed, vec![entry.ip]);
+    }
+
+    #[test]
+    fn next_refresh_tracks_soonest_expiry() {
+        let mut cache = DnsCache::default();
+        let now = Instant::now();
+        cache.apply(
+            "example.com",
+            now,
+            vec![Entry {
+                ip: Ipv4Addr::new(1, 1, 1, 1),
+                expires_at: now + Duration::from_secs(5),
+            }],
+        );
+        cache.apply(
+            "example.net",
+            now,
+            vec![Entry {
+                ip: Ipv4Addr::new(2, 2, 2, 2),
+                expires_at: now + Duration::from_secs(10),
+            }],
+        );
+
+        let refresh = cache.next_refresh_in(now).expect("has entries");
+        assert_eq!(refresh, Duration::from_secs(5));
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -4,4 +4,4 @@ pub mod resolver;
 
 // Re-export main types and functions
 pub use parser::{NetworkRules, parse_allow_network};
-pub use resolver::{ResolvedAddresses, resolve_domains};
+pub use resolver::{DnsResolver, ResolvedAddresses, SystemDnsResolver};

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod parser;
 pub mod resolver;
 

--- a/src/net/resolver.rs
+++ b/src/net/resolver.rs
@@ -5,6 +5,9 @@ use std::{
 
 use hickory_resolver::{Resolver, config::ResolverConfig, system_conf};
 
+#[cfg(test)]
+use mockall::automock;
+
 use super::cache::Entry;
 use crate::error::MoriError;
 
@@ -22,73 +25,86 @@ pub struct ResolvedAddresses {
     pub dns_v4: Vec<Ipv4Addr>,
 }
 
-/// Resolve domain names to IPv4 addresses and collect DNS server IPs
-///
-/// This function performs DNS resolution for the provided domain names and also
-/// extracts the IPv4 addresses of the DNS servers themselves (which need to be
-/// allowed for DNS queries to work).
-///
-/// # Arguments
-/// * `domains` - List of domain names to resolve
-///
-/// # Returns
-/// * `Ok(ResolvedAddresses)` - Contains resolved IPv4 addresses from domains and DNS server IPs
-/// * `Err(MoriError)` - If DNS resolver initialization or lookup fails
-///
-/// # Examples
-/// ```
-/// use mori::net::resolver::resolve_domains;
-///
-/// let domains = vec!["example.com".to_string()];
-/// let resolved = resolve_domains(&domains).unwrap();
-/// ```
-pub fn resolve_domains(domains: &[String]) -> Result<ResolvedAddresses, MoriError> {
-    if domains.is_empty() {
-        return Ok(ResolvedAddresses::default());
-    }
+/// DNS resolver abstraction for testing
+#[cfg_attr(test, automock)]
+pub trait DnsResolver: Send + Sync + 'static {
+    fn resolve_domains(&self, domains: &[String]) -> Result<ResolvedAddresses, MoriError>;
+}
 
-    let (config, opts) =
-        system_conf::read_system_conf().map_err(|source| MoriError::DnsResolverInit { source })?;
+/// Production DNS resolver using the system resolver
+pub struct SystemDnsResolver;
 
-    let resolver = Resolver::new(config.clone(), opts).map_err(MoriError::Io)?;
+impl DnsResolver for SystemDnsResolver {
+    /// Resolve domain names to IPv4 addresses and collect DNS server IPs
+    ///
+    /// This function performs DNS resolution for the provided domain names and also
+    /// extracts the IPv4 addresses of the DNS servers themselves (which need to be
+    /// allowed for DNS queries to work).
+    ///
+    /// # Arguments
+    /// * `domains` - List of domain names to resolve
+    ///
+    /// # Returns
+    /// * `Ok(ResolvedAddresses)` - Contains resolved IPv4 addresses from domains and DNS server IPs
+    /// * `Err(MoriError)` - If DNS resolver initialization or lookup fails
+    ///
+    /// # Examples
+    /// ```
+    /// use crate::mori::net::SystemDnsResolver;
+    /// use crate::mori::net::DnsResolver as _;
+    ///
+    /// let resolver = SystemDnsResolver;
+    /// let domains = vec!["example.com".to_string()];
+    /// let resolved = resolver.resolve_domains(&domains).unwrap();
+    /// ```
+    fn resolve_domains(&self, domains: &[String]) -> Result<ResolvedAddresses, MoriError> {
+        if domains.is_empty() {
+            return Ok(ResolvedAddresses::default());
+        }
 
-    let nameservers = collect_nameserver_ips(&config);
+        let (config, opts) = system_conf::read_system_conf()
+            .map_err(|source| MoriError::DnsResolverInit { source })?;
 
-    let mut domain_records = Vec::with_capacity(domains.len());
+        let resolver = Resolver::new(config.clone(), opts).map_err(MoriError::Io)?;
 
-    for domain in domains {
-        let response =
-            resolver
-                .lookup_ip(domain.as_str())
-                .map_err(|source| MoriError::DnsLookup {
+        let nameservers = collect_nameserver_ips(&config);
+
+        let mut domain_records = Vec::with_capacity(domains.len());
+
+        for domain in domains {
+            let response =
+                resolver
+                    .lookup_ip(domain.as_str())
+                    .map_err(|source| MoriError::DnsLookup {
+                        domain: domain.clone(),
+                        source,
+                    })?;
+
+            let valid_until = response.valid_until();
+            let mut records = Vec::new();
+
+            for ip in response.iter() {
+                if let IpAddr::V4(v4) = ip {
+                    records.push(Entry {
+                        ip: v4,
+                        expires_at: valid_until,
+                    });
+                }
+            }
+
+            if !records.is_empty() {
+                domain_records.push(DomainRecords {
                     domain: domain.clone(),
-                    source,
-                })?;
-
-        let valid_until = response.valid_until();
-        let mut records = Vec::new();
-
-        for ip in response.iter() {
-            if let IpAddr::V4(v4) = ip {
-                records.push(Entry {
-                    ip: v4,
-                    expires_at: valid_until,
+                    records,
                 });
             }
         }
 
-        if !records.is_empty() {
-            domain_records.push(DomainRecords {
-                domain: domain.clone(),
-                records,
-            });
-        }
+        Ok(ResolvedAddresses {
+            domains: domain_records,
+            dns_v4: nameservers,
+        })
     }
-
-    Ok(ResolvedAddresses {
-        domains: domain_records,
-        dns_v4: nameservers,
-    })
 }
 
 /// Extract IPv4 addresses of DNS nameservers from resolver configuration
@@ -115,7 +131,8 @@ mod tests {
     #[test]
     fn test_resolve_domain_success() {
         let domains = vec!["localhost".to_string()];
-        let resolved = resolve_domains(&domains).unwrap();
+        let resolver = SystemDnsResolver;
+        let resolved = resolver.resolve_domains(&domains).unwrap();
         let record = resolved
             .domains
             .iter()


### PR DESCRIPTION
## Summary
- Implemented DNS cache with TTL-based domain refresh management
- Added thread-safe refresh loop for DNS record updates
- Introduced `ShutdownSignal` abstraction for clean thread coordination
- Added comprehensive unit tests with mocking support

## Changes

### DNS Cache Implementation
- Created `DnsCache` for tracking domain-to-IP mappings with expiration times
- Implements `apply()` method to calculate diffs (added/removed IPs) between cache states
- Provides `next_refresh_in()` to determine optimal refresh interval based on TTL

### DNS Resolver Enhancement
- Refactored DNS resolution to return TTL-aware records per domain
- Added `DnsResolver` trait for testability with `SystemDnsResolver` implementation
- DNS records now include expiration timestamps from DNS TTL

### Background Refresh Thread
- Spawns refresh thread for automatic DNS record updates
- Thread sleeps until earliest TTL expiration, then re-resolves domains
- Integrates with eBPF maps to add/remove IPs based on DNS changes
- Tracks DNS server IPs separately to avoid duplication

### Thread Coordination
- Introduced `ShutdownSignal` combining Condvar and AtomicBool
- Ensures graceful thread termination on main process exit
- `wait_timeout_or_shutdown()` method prevents missed shutdown signals

### Testing Infrastructure
- Added `mockall` dependency for unit testing
- Created `EbpfController` trait for mocking eBPF operations
- Added comprehensive tests for cache behavior, thread lifecycle, and error handling

## Test Plan
- [x] Unit tests for DNS cache diff calculation
- [x] Unit tests for TTL-based refresh timing
- [x] Unit tests for thread shutdown behavior
- [x] Unit tests for DNS resolver with mocking
- [x] Integration test verifying actual DNS resolution
- [x] Manual testing with real domains and network restrictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)